### PR TITLE
Python 3.8 compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+/.idea
 *.egg-info
 __pycache__
 testrun.py

--- a/nocodb/Base.py
+++ b/nocodb/Base.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 if TYPE_CHECKING:
     from nocodb import NocoDB
 
@@ -45,7 +45,7 @@ class Base:
         r = self.noco_db.call_noco(path=f"meta/bases/{self.base_id}/info")
         return r.json()
 
-    def get_tables(self) -> list[Table]:
+    def get_tables(self) -> List[Table]:
         r = self.noco_db.call_noco(path=f"meta/bases/{self.base_id}/tables")
         return [Table(base=self, **t) for t in r.json()["list"]]
 
@@ -61,7 +61,7 @@ class Base:
             raise Exception(f"Table with name {title} not found!")
 
     def create_table(self, table_name: str,
-                      columns: list[dict] = None, add_default_columns: bool = True,
+                      columns: List[dict] = None, add_default_columns: bool = True,
                      **kwargs) -> Table:
         if columns is None:
             columns = []

--- a/nocodb/Base.py
+++ b/nocodb/Base.py
@@ -61,8 +61,10 @@ class Base:
             raise Exception(f"Table with name {title} not found!")
 
     def create_table(self, table_name: str,
-                      columns: list[dict] = [], add_default_columns: bool = True, 
+                      columns: list[dict] = None, add_default_columns: bool = True,
                      **kwargs) -> Table:
+        if columns is None:
+            columns = []
         kwargs["table_name"] = table_name
         if not columns:
             kwargs["columns"] = Column.get_id_metadata()

--- a/nocodb/Column.py
+++ b/nocodb/Column.py
@@ -1,3 +1,6 @@
+from typing import List
+
+
 class Column:
     def __init__(self, **kwargs) -> None:
         self.title = kwargs["title"]
@@ -7,7 +10,7 @@ class Column:
         self.metadata = kwargs
 
     @staticmethod
-    def get_id_metadata() -> list[dict]:
+    def get_id_metadata() -> List[dict]:
         return [
             {'title': 'Id', 'column_name': 'id', 'uidt': 'ID',
              'dt': 'int4', 'np': '11', 'ns': '0', 'clen': None,

--- a/nocodb/Record.py
+++ b/nocodb/Record.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from nocodb.Column import Column
 if TYPE_CHECKING:
@@ -21,7 +21,7 @@ class Record:
 
         return r.json()
 
-    def link_records(self, column: Column, link_records: list["Record"]) -> bool:
+    def link_records(self, column: Column, link_records: List["Record"]) -> bool:
         path = (f"tables/{self.table.table_id}/links/" +
                 f"{column.column_id}/records/{self.record_id}")
         r = self.noco_db.call_noco(path=path,

--- a/nocodb/Record.py
+++ b/nocodb/Record.py
@@ -14,16 +14,16 @@ class Record:
         self.metadata = kwargs
 
     def link_record(self, column: Column, link_record: "Record") -> bool:
-        path = f"tables/{self.table.table_id}/links/{
-            column.column_id}/records/{self.record_id}"
+        path = (f"tables/{self.table.table_id}/links/" +
+                f"{column.column_id}/records/{self.record_id}")
         r = self.noco_db.call_noco(path=path,
                                    method="POST", json={"Id": link_record.record_id})
 
         return r.json()
 
     def link_records(self, column: Column, link_records: list["Record"]) -> bool:
-        path = f"tables/{self.table.table_id}/links/{
-            column.column_id}/records/{self.record_id}"
+        path = (f"tables/{self.table.table_id}/links/" +
+                f"{column.column_id}/records/{self.record_id}")
         r = self.noco_db.call_noco(path=path,
                                    method="POST", json=[{"Id": l.record_id} for l in link_records])
 

--- a/nocodb/Table.py
+++ b/nocodb/Table.py
@@ -1,7 +1,7 @@
 from nocodb.Record import Record
 from nocodb.Column import Column
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 if TYPE_CHECKING:
     from nocodb.Base import Base
 
@@ -26,7 +26,7 @@ class Table:
             path=f"tables/{self.table_id}/records/count")
         return r.json()["count"]
 
-    def get_columns(self, include_system: bool = True) -> list[Column]:
+    def get_columns(self, include_system: bool = True) -> List[Column]:
         r = self.noco_db.call_noco(
             path=f"meta/tables/{self.table_id}")
         cols = [Column(**f) for f in r.json()["columns"]]
@@ -73,7 +73,7 @@ class Table:
                                    method="DELETE")
         return r.json()
 
-    def get_records(self, params: dict = None) -> list[Record]:
+    def get_records(self, params: dict = None) -> List[Record]:
         if params is None:
             params = {}
 
@@ -107,7 +107,7 @@ class Table:
             path=f"tables/{self.table_id}/records/{record_id}")
         return Record(self, **r.json())
 
-    def get_records_by_field_value(self, field: str, value) -> list[Record]:
+    def get_records_by_field_value(self, field: str, value) -> List[Record]:
         return self.get_records(params={"where": f"({field},eq,{value})"})
 
     def create_record(self, **kwargs) -> Record:
@@ -116,7 +116,7 @@ class Table:
                                    json=kwargs)
         return self.get_record(record_id=r.json()["Id"])
 
-    def create_records(self, records: list[dict]) -> list[Record]:
+    def create_records(self, records: List[dict]) -> List[Record]:
         r = self.noco_db.call_noco(path=f"tables/{self.table_id}/records",
                                    method="POST",
                                    json=records)

--- a/nocodb/Table.py
+++ b/nocodb/Table.py
@@ -1,4 +1,3 @@
-
 from nocodb.Record import Record
 from nocodb.Column import Column
 
@@ -74,7 +73,9 @@ class Table:
                                    method="DELETE")
         return r.json()
 
-    def get_records(self, params: dict = {}) -> list[Record]:
+    def get_records(self, params: dict = None) -> list[Record]:
+        if params is None:
+            params = {}
 
         if any([p in params for p in ["offset", "limit"]]):
             get_all_records = False
@@ -85,9 +86,7 @@ class Table:
             params["limit"] = 1000
 
         records = []
-
         while True:
-
             r = self.noco_db.call_noco(
                 path=f"tables/{self.table_id}/records", params=params)
 

--- a/nocodb/__init__.py
+++ b/nocodb/__init__.py
@@ -1,3 +1,4 @@
+from typing import List
 from nocodb.Base import Base
 import requests
 from urllib.parse import urlsplit, urljoin
@@ -68,7 +69,7 @@ class NocoDB:
         return r
 
 
-    def get_bases(self) -> list[Base]:
+    def get_bases(self) -> List[Base]:
         r = self.call_noco(path="meta/bases")
         return [Base(noco_db=self, **f) for f in r.json()["list"]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "py-nocodb"
 version = "0.0.1"
 description = "Python client for NocoDB API v2"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 authors = [{ name = "infeeeee", email = "gyetpet@mailbox.org" }]
 maintainers = [{ name = "infeeeee", email = "gyetpet@mailbox.org" }]


### PR DESCRIPTION
It seems to be only difference in type hints, all other stuff works fine on Python 3.8 (works in my case, but of course need to be approved by unit-tests).